### PR TITLE
Fix bs-platform dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "re",
     "version": "1.7.1",
-    "dependencies": {
-       "bs-platform": "bsansouci/bucklescript#simple-native-compilation" 
+    "devDependencies": {
+       "bs-platform": "bsansouci/bsb-native" 
     }
 }


### PR DESCRIPTION
Currently the npm install fails because `bsansouci/bucklescript#simple-native-compilation` doesn't exist anymore